### PR TITLE
Handle convert fail

### DIFF
--- a/pkg/media/convert/h264_codec.go
+++ b/pkg/media/convert/h264_codec.go
@@ -27,7 +27,7 @@ func (c *H264Codec) configure(mediaFile *ffmpegModels.Mediafile) error {
 	mediaFile.SetHideBanner(true)
 	mediaFile.SetVsync(true)
 	mediaFile.SetAudioCodec("copy")
-	mediaFile.SetMaxMuxingQueueSize(2048)
+	mediaFile.SetMaxMuxingQueueSize(102400)
 
 	if c.task.VideoQuality > 0 {
 		mediaFile.SetCRF(uint32(c.task.VideoQuality))

--- a/pkg/media/convert/hevc_codec.go
+++ b/pkg/media/convert/hevc_codec.go
@@ -27,7 +27,7 @@ func (c *HevcCodec) configure(mediaFile *ffmpegModels.Mediafile) error {
 	mediaFile.SetHideBanner(true)
 	mediaFile.SetVsync(true)
 	mediaFile.SetAudioCodec("copy")
-	mediaFile.SetMaxMuxingQueueSize(2048)
+	mediaFile.SetMaxMuxingQueueSize(102400)
 	mediaFile.SetVideoTag("hvc1")
 
 	if c.task.VideoQuality > 0 {


### PR DESCRIPTION
Fixed bug: when conversion failed, batch converter keeps creating tasks & cancelling it right after, until the end. Once converting is done, exit code is 0. 

Should be: stop conversion right after conversion fail happened & exit with != 0 code.