### PR TITLE
Use QP instead of CRF in CPU mode

### DIFF
--- a/pkg/goffmpeg/models/media.go
+++ b/pkg/goffmpeg/models/media.go
@@ -100,6 +100,7 @@ type Mediafile struct {
 // Libx265Params _
 type Libx265Params struct {
 	CRF uint32
+	QP  uint32
 }
 
 /*** SETTERS ***/
@@ -1371,11 +1372,13 @@ func (m *Mediafile) ObtainLibx265Params() []string {
 			flags = append(flags, fmt.Sprintf("crf=%d", m.libx265Params.CRF))
 		}
 
-		if len(flags) > 0 {
-			flags = append([]string{"-x265-params"}, flags...)
+		if m.libx265Params.QP > 0 {
+			flags = append(flags, fmt.Sprintf("qp=%d", m.libx265Params.QP))
 		}
 
-		return flags
+		if len(flags) > 0 {
+			return []string{"-x265-params", strings.Join(flags, " ")}
+		}
 	}
 
 	return nil

--- a/pkg/media/convert/h264_codec.go
+++ b/pkg/media/convert/h264_codec.go
@@ -30,7 +30,7 @@ func (c *H264Codec) configure(mediaFile *ffmpegModels.Mediafile) error {
 	mediaFile.SetMaxMuxingQueueSize(102400)
 
 	if c.task.VideoQuality > 0 {
-		mediaFile.SetCRF(uint32(c.task.VideoQuality))
+		mediaFile.SetConstantQuantization(c.task.VideoQuality)
 	} else {
 		mediaFile.SetVideoBitRate(c.task.VideoBitRate)
 	}

--- a/pkg/media/convert/hevc_codec.go
+++ b/pkg/media/convert/hevc_codec.go
@@ -31,7 +31,7 @@ func (c *HevcCodec) configure(mediaFile *ffmpegModels.Mediafile) error {
 	mediaFile.SetVideoTag("hvc1")
 
 	if c.task.VideoQuality > 0 {
-		mediaFile.SetLibx265Params(&ffmpegModels.Libx265Params{CRF: uint32(c.task.VideoQuality)})
+		mediaFile.SetLibx265Params(&ffmpegModels.Libx265Params{QP: uint32(c.task.VideoQuality)})
 	} else {
 		mediaFile.SetVideoBitRate(c.task.VideoBitRate)
 	}


### PR DESCRIPTION
`qp` option is used in NVENC encoder so I'm expecting that nvenc task & cpu task should produce slightly the same picture. But picture with CRF=30 (CPU) is a lot worse than QP=30 (NVENC)